### PR TITLE
Remove current unused `console.log` and log warnings

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -54,7 +54,11 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+    <script src="./TW-ELEMENTS-PATH/dist/js/index.min.js" type="text/css"></script>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/@material-tailwind/html@latest/scripts/select.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
+    <script src="https://unpkg.com/@material-tailwind/html@latest/scripts/ripple.js"></script>
     <script>
       tailwind.config = {
         theme: {
@@ -66,8 +70,5 @@
         }
       }
     </script>
-    <script src="https://unpkg.com/@material-tailwind/html@latest/scripts/select.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
-    <script src="https://unpkg.com/@material-tailwind/html@latest/scripts/ripple.js"></script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -24,35 +24,21 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <link
-  href="https://fonts.googleapis.com/icon?family=Material+Icons"
-  rel="stylesheet"
-/>
-    <link
-  rel="stylesheet"
-  href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/css/all.min.css"
-  integrity="sha512-HK5fgLBL+xu6dm/Ii3z4xhlSUyZgTT9tuc/hSrtw6uzJOvgRr2a9jyxxT1ely+B+xFAmJKVSTbpM/CuL7qxO8w=="
-  crossorigin="anonymous"
-/>
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/css/all.min.css"
+      integrity="sha512-HK5fgLBL+xu6dm/Ii3z4xhlSUyZgTT9tuc/hSrtw6uzJOvgRr2a9jyxxT1ely+B+xFAmJKVSTbpM/CuL7qxO8w=="
+      crossorigin="anonymous"
+    />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" />
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" />
-<link
-href="https://unpkg.com/@material-tailwind/html@latest/styles/material-tailwind.css"
-rel="stylesheet"
-/>
-<link href="/src/output.css" rel="stylesheet">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tw-elements/dist/css/index.min.css" />
-<script>
-  tailwind.config = {
-    theme: {
-      extend: {
-        fontFamily: {
-          sans: ['Inter', 'sans-serif'],
-        },
-      }
-    }
-  }
-</script>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" />
+    <link
+      href="https://unpkg.com/@material-tailwind/html@latest/styles/material-tailwind.css"
+      rel="stylesheet"
+    />
+    <link href="/src/output.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tw-elements/dist/css/index.min.css" />
     <title>Issue Finder</title>
   </head>
   <body>
@@ -70,6 +56,17 @@ rel="stylesheet"
     -->
     <script src="./TW-ELEMENTS-PATH/dist/js/index.min.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ['Inter', 'sans-serif'],
+            },
+          }
+        }
+      }
+    </script>
     <script src="node_modules/@material-tailwind/html@latest/scripts/ripple.js"></script>
     <script src="https://unpkg.com/@material-tailwind/html@latest/scripts/select.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>

--- a/public/index.html
+++ b/public/index.html
@@ -54,7 +54,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    <script src="./TW-ELEMENTS-PATH/dist/js/index.min.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {
@@ -67,7 +66,6 @@
         }
       }
     </script>
-    <script src="node_modules/@material-tailwind/html@latest/scripts/ripple.js"></script>
     <script src="https://unpkg.com/@material-tailwind/html@latest/scripts/select.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
     <script src="https://unpkg.com/@material-tailwind/html@latest/scripts/ripple.js"></script>

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -14,7 +14,6 @@ export const getIssues = (org, repo, label) => async (dispatch) => {
   });
   try {
     const { data } = await api.fetchIssues(org, repo, label);
-    console.log(data);
     dispatch({
       type: issue.GET_ISSUES_SUCCESS,
       payload: data
@@ -56,12 +55,6 @@ export const setLanguage = (language) => (dispatch) => {
 };
 
 export const rawLabels = async (repos, dispatch) => {
-  // const repos = await fetchRepos();
-  console.log(
-    `from inside rawLabelssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss ${JSON.stringify(
-      repos
-    )}`
-  );
   let rawdata = [];
   for (let i = 0; i < repos.length; i++) {
     const item = repos[i];
@@ -70,7 +63,6 @@ export const rawLabels = async (repos, dispatch) => {
       const label = labels.data[j];
       rawdata.push(label.name);
     }
-    console.log(`loading ${(i * 100) / repos.length} %`);
     dispatch({
       type: label.GET_LABELS_REQUEST,
       loadingPercentage: (i * 100) / repos.length
@@ -81,8 +73,6 @@ export const rawLabels = async (repos, dispatch) => {
 
 export const getLabels = (repos) => async (dispatch, getState) => {
   if (repos === undefined) return;
-  console.log('Hello world');
-  console.log(`inside getLabels ${JSON.stringify(repos)}`);
   dispatch({
     type: label.GET_LABELS_REQUEST,
     loadingPercentage: 0
@@ -106,7 +96,6 @@ export const getLabels = (repos) => async (dispatch, getState) => {
     let data = '';
     if (localData) data = JSON.parse(localData);
     else data = await rawLabels(repos, dispatch); // if label list is not present in local storage than get fresh list of labels.
-    console.log(`inside getLabels 2 ${data}`);
     dispatch({
       type: label.GET_LABELS_SUCCESS,
       payload: data
@@ -114,7 +103,7 @@ export const getLabels = (repos) => async (dispatch, getState) => {
     localStorage.setItem('labelslist', JSON.stringify(getState().labelsStore.labelslist));
     localStorage.setItem('date', today);
   } catch (e) {
-    console.log(`getlabels error ${e.message}`);
+    console.error(`getlabels error ${e.message}`);
     dispatch({
       type: label.GET_LABELS_FAIL,
       error: e.message

--- a/src/api/label_grouping/label_grouping.js
+++ b/src/api/label_grouping/label_grouping.js
@@ -42,5 +42,5 @@ setTimeout(() => {
 
 // verify normalize label names values
 setTimeout(() => {
-  console.log(norm_labels);
+  console.info(norm_labels);
 }, 3000);

--- a/src/components/SearchEngine.js
+++ b/src/components/SearchEngine.js
@@ -4,10 +4,8 @@ import { getLabels } from '../actions';
 
 export const SearchEngine = () => {
   const dispatch = useDispatch();
-  // const labels = useSelector((state) => state.labelsStore);
   const repos = useSelector((state) => state.reposStore);
-  console.log(`from searchengine ${JSON.stringify(repos)}`);
-  // console.log(process.env.REACT_APP_API_KEY)
+
   useEffect(
     () => {
       dispatch(getLabels(repos.reposlist));
@@ -15,9 +13,4 @@ export const SearchEngine = () => {
     // eslint-disable-next-line
     [repos]
   );
-  // return (
-  //   <div>
-  //       {JSON.stringify(labels)}
-  //   </div>
-  // );
 };

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,3 @@ root.render(
     <App />
   </Provider>
 );
-
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { Provider } from 'react-redux';
 import store from './store';
 import App from './containers/App';
+import 'tw-elements';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(

--- a/src/snippets/github_scraper.js
+++ b/src/snippets/github_scraper.js
@@ -11,11 +11,10 @@ dotenv.config();
       }
     });
     const ghJson = await gh.json();
-    // console.log(ghJson);
     if (ghJson.message !== 'Not Found') {
       ghJson.forEach((repo) => {
         if (repo.language === 'JavaScript' || repo.language === 'Ruby') {
-          console.log(
+          console.info(
             `${repo.open_issues_count}, https://github.com/${repo.full_name}, ${repo.language}`
           );
         }


### PR DESCRIPTION
The following changes were made:

- Remove `console.log`(s) from some files that were previously used to debug, and replace some others that may be useful wit `console.info` or `console.error`
- Remove current commented code. This can be accessed checking out to a previous commit
- Move script tag containing `tailwind.config` to file bottom since there was a log warning referring `tailwind` was not found
- Reorder script tags on bottom file and replace `ripple.js` script from `node_modules` with one from cdn (as in `material-tailwind` [documentation](https://www.material-tailwind.com/docs/html/installation))
- Equally-indent HTML header tags