### PR TITLE
fix: #28 Disable Tailwind Preflight enabling default heading tags styles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -61,6 +61,9 @@
     <script src="https://unpkg.com/@material-tailwind/html@latest/scripts/ripple.js"></script>
     <script>
       tailwind.config = {
+        corePlugins: {
+          preflight: false
+        },
         theme: {
           extend: {
             fontFamily: {


### PR DESCRIPTION
As discussed [in Tailwind docs](https://tailwindcss.com/docs/preflight) and [here](https://github.com/tailwindlabs/tailwindcss/issues/1460) this behavior is intentional.

I tried overriding base styles for headings without success, for now I disabled Preflight.