### PR TITLE
Load All labels from selected language only

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -76,7 +76,7 @@ export const rawLabels = async (repos, dispatch) => {
   return rawdata;
 };
 
-export const getLabels = (repos) => async (dispatch, getState) => {
+export const getLabels = (repos, language) => async (dispatch, getState) => {
   if (repos === undefined) return;
   dispatch({
     type: label.GET_LABELS_REQUEST,
@@ -84,7 +84,8 @@ export const getLabels = (repos) => async (dispatch, getState) => {
   });
   try {
     // get date for list of labels, saved in browser's local strorage
-    const localDataDate = localStorage.getItem('date');
+    const localStorageObj = JSON.parse(localStorage.getItem(language + '_labelslist'));
+    const localDataDate = localStorageObj?.date;
     let today = new Date();
     const dd = String(today.getDate()).padStart(2, '0');
     const mm = String(today.getMonth() + 1).padStart(2, '0');
@@ -92,21 +93,22 @@ export const getLabels = (repos) => async (dispatch, getState) => {
     today = (mm + dd + yyyy).toString();
     // if date, when data was saved, is more than a day, clear it.
     if (localDataDate !== today) {
-      localStorage.removeItem('labelslist');
-      localStorage.removeItem('date');
+      localStorage.removeItem(language + '_labelslist');
     }
 
     // get label list from local storage
-    const localData = localStorage.getItem('labelslist');
+    const localData = localStorageObj?.labels;
     let data = '';
-    if (localData) data = JSON.parse(localData);
+    if (localData) data = localData;
     else data = await rawLabels(repos, dispatch); // if label list is not present in local storage than get fresh list of labels.
     dispatch({
       type: label.GET_LABELS_SUCCESS,
       payload: data
     });
-    localStorage.setItem('labelslist', JSON.stringify(getState().labelsStore.labelslist));
-    localStorage.setItem('date', today);
+    localStorage.setItem(
+      language + '_labelslist',
+      JSON.stringify({ language: language, date: today, labels: getState().labelsStore.labelslist })
+    );
   } catch (e) {
     console.error(`getlabels error ${e.message}`);
     dispatch({

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -127,7 +127,7 @@ const Home = () => {
           </Select>
           <Button
             variant={`${darkMode ? 'light' : 'dark'} button button-green w-full h-15`}
-            disabled={loading || (menu === 2 && label === 'All')}
+            disabled={loading}
             onClick={() => findIssues()}>
             {label === 'All' ? 'Load Labels' : 'Find Issues'}
           </Button>

--- a/src/components/SearchEngine.js
+++ b/src/components/SearchEngine.js
@@ -17,6 +17,6 @@ export const SearchEngine = () => {
       dispatch(getLabels(filteredRepolist, language));
     },
     // eslint-disable-next-line
-    [repos]
+    [repos, language]
   );
 };

--- a/src/components/SearchEngine.js
+++ b/src/components/SearchEngine.js
@@ -5,10 +5,16 @@ import { getLabels } from '../actions';
 export const SearchEngine = () => {
   const dispatch = useDispatch();
   const repos = useSelector((state) => state.reposStore);
+  const { language } = useSelector((state) => state.issuesStore);
 
   useEffect(
     () => {
-      dispatch(getLabels(repos.reposlist));
+      const filteredRepolist = repos.reposlist.filter(
+        (repo) =>
+          repo.language.trim() === language ||
+          repo.topics?.trim().toLowerCase().split(' ').includes(language.toLowerCase())
+      );
+      dispatch(getLabels(filteredRepolist, language));
     },
     // eslint-disable-next-line
     [repos]


### PR DESCRIPTION
Earlier on selecting 'all', labels were loaded from all repositories. This pr loads All labels from the 'selected language' only.